### PR TITLE
Allow the request to receive a system prompt parameter

### DIFF
--- a/ai_server/server.py
+++ b/ai_server/server.py
@@ -93,20 +93,18 @@ def chat_with_llamacpp(model: str, content: str, system_prompt: Optional[str] = 
     if not model_path:
         raise ValueError(f"Model not found: {model}")
     
-    # Format prompt with system prompt if provided
-    if system_prompt:
-        formatted_prompt = f"System: {system_prompt}\n\nUser: {content}\n\nAssistant:"
-    else:
-        formatted_prompt = content
-    
     cmd = [
         LLAMA_CPP_CLI,
         '-m', model_path,
         '--n-gpu-layers', '40',
-        '-p', formatted_prompt,
+        '-p', content,
         '-n', '512',
         '--single-turn'
     ]
+    
+    # Add system prompt if provided
+    if system_prompt:
+        cmd.extend(['--system-prompt', system_prompt])
     
     try:
         result = subprocess.run(

--- a/ai_server/server.py
+++ b/ai_server/server.py
@@ -25,16 +25,21 @@ GGUF_DIR = os.getenv('GGUF_DIR', '/data1/GGUF')
 _llama_server_url = os.getenv('LLAMA_SERVER_URL')  # e.g., http://localhost:8080 or localhost:8080
 LLAMA_SERVER_URL = f"http://{_llama_server_url}" if _llama_server_url and not _llama_server_url.startswith(('http://', 'https://')) else _llama_server_url
 
+def _build_messages(content: str, system_prompt: Optional[str] = None) -> list:
+    """Build messages list with optional system prompt."""
+    messages = []
+    if system_prompt:
+        messages.append({'role': 'system', 'content': system_prompt})
+    messages.append({'role': 'user', 'content': content})
+    return messages
+
 def chat_with_llama_server_http(model: str, content: str, system_prompt: Optional[str] = None, timeout: int = 300) -> str:
     """Handle chat using llama-server HTTP API."""
     if not LLAMA_SERVER_URL:
         raise Exception("LLAMA_SERVER_URL environment variable not set")
     
     try:
-        messages = []
-        if system_prompt:
-            messages.append({'role': 'system', 'content': system_prompt})
-        messages.append({'role': 'user', 'content': content})
+        messages = _build_messages(content, system_prompt)
         
         response = requests.post(
             f'{LLAMA_SERVER_URL}/v1/chat/completions',
@@ -74,10 +79,7 @@ def is_llamacpp_available(model: str) -> bool:
 
 def chat_with_ollama(model: str, content: str, system_prompt: Optional[str] = None) -> str:
     """Handle chat using ollama."""
-    messages = []
-    if system_prompt:
-        messages.append({'role': 'system', 'content': system_prompt})
-    messages.append({'role': 'user', 'content': content})
+    messages = _build_messages(content, system_prompt)
     
     response = ollama.chat(
         model=model,

--- a/ai_server/server.py
+++ b/ai_server/server.py
@@ -1,11 +1,137 @@
 from flask import Flask, request, jsonify, abort
 import ollama
+import subprocess
+import os
+import requests
+from typing import Optional
+from dotenv import load_dotenv
+import glob
 
 from .redis_helper import REDIS_CONNECTION
 
+# Load environment variables from .env file
+load_dotenv()
+
 app = Flask('AI server')
 
-DEFAULT_MODEL = 'deepseek-coder-v2:latest'
+# Configuration from environment variables
+DEFAULT_MODEL = os.getenv('DEFAULT_MODEL', 'deepseek-coder-v2:latest')
+
+# Llama.cpp configuration
+LLAMA_CPP_CLI = os.getenv('LLAMA_CPP_CLI', '/data1/llama.cpp/bin/llama-cli')
+GGUF_DIR = os.getenv('GGUF_DIR', '/data1/GGUF')
+
+# Llama server configuration
+_llama_server_url = os.getenv('LLAMA_SERVER_URL')  # e.g., http://localhost:8080 or localhost:8080
+LLAMA_SERVER_URL = f"http://{_llama_server_url}" if _llama_server_url and not _llama_server_url.startswith(('http://', 'https://')) else _llama_server_url
+
+def chat_with_llama_server_http(model: str, content: str, timeout: int = 300) -> str:
+    """Handle chat using llama-server HTTP API."""
+    if not LLAMA_SERVER_URL:
+        raise Exception("LLAMA_SERVER_URL environment variable not set")
+    
+    try:
+        response = requests.post(
+            f'{LLAMA_SERVER_URL}/v1/chat/completions',
+            json={
+                'model': model,
+                'messages': [{'role': 'user', 'content': content}],
+                'stream': False,
+                'max_tokens': 512
+            },
+            headers={'Content-Type': 'application/json'},
+            timeout=timeout
+        )
+        
+        if response.status_code == 200:
+            data = response.json()
+            if 'choices' in data and len(data['choices']) > 0:
+                return data['choices'][0]['message']['content']
+            else:
+                raise Exception("Invalid response format from llama-server")
+        else:
+            raise Exception(f"Llama-server HTTP error")
+                
+    except requests.Timeout:
+        raise Exception(f"Llama-server request timed out for model {model}")
+    except requests.RequestException as e:
+        raise Exception(f"Llama-server request failed: {str(e)}")
+
+def resolve_model_path(model: str) -> Optional[str]:
+    """Resolve model name to full GGUF file path using glob pattern."""
+    pattern = os.path.join(GGUF_DIR, model, "*.gguf")
+    matches = glob.glob(pattern)
+    return matches[0] if matches else None
+
+def is_llamacpp_available(model: str) -> bool:
+    """Check if model is available in llama.cpp."""
+    return resolve_model_path(model) is not None
+
+def chat_with_ollama(model: str, content: str) -> str:
+    """Handle chat using ollama."""
+    response = ollama.chat(
+        model=model,
+        messages=[{'role': 'user', 'content': content}],
+        stream=False
+    )
+    return response.message.content
+
+def chat_with_llamacpp(model: str, content: str, timeout: int = 300) -> str:
+    """Handle chat using llama.cpp CLI."""
+    model_path = resolve_model_path(model)
+    
+    if not model_path:
+        raise ValueError(f"Model not found: {model}")
+    
+    cmd = [
+        LLAMA_CPP_CLI,
+        '-m', model_path,
+        '--n-gpu-layers', '40',
+        '-p', content,
+        '-n', '512',
+        '--single-turn'
+    ]
+    
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=False,
+            timeout=timeout,
+            check=True
+        )
+        
+        stdout_text = result.stdout.decode('utf-8', errors='replace')
+
+        # Strip whitespace and return the response
+        response = stdout_text.strip()
+        return response if response else "No response generated."
+        
+    except subprocess.TimeoutExpired:
+        raise Exception(f"Llama.cpp request timed out for model {model}")
+    except subprocess.CalledProcessError as e:
+        stderr_text = ""
+        if e.stderr:
+            stderr_text = e.stderr.decode('utf-8', errors='replace')
+        raise Exception(f"Llama.cpp failed for {model}: {stderr_text.strip() if stderr_text else 'Unknown error'}")
+    except FileNotFoundError:
+        raise Exception("Llama.cpp CLI not found")
+
+def chat_with_model(model: str, content: str, llama_mode: str = "cli") -> str:
+    """Route chat request based on llama_mode: server (external), cli, or ollama fallback."""
+    if is_llamacpp_available(model):
+        if llama_mode == "server":
+            if not LLAMA_SERVER_URL:
+                raise Exception("LLAMA_SERVER_URL environment variable not set for server mode")
+            return chat_with_llama_server_http(model, content)
+        elif llama_mode == "cli":
+            return chat_with_llamacpp(model, content)
+        else:
+            raise ValueError(f"Invalid llama_mode: '{llama_mode}'. Valid options are 'server' or 'cli'.")
+    else:
+        # Model not available in llama.cpp, use ollama
+        return chat_with_ollama(model, content)
+
 
 def authenticate() -> str:
     """Authenticate the given request using an API key."""
@@ -22,21 +148,18 @@ def authenticate() -> str:
 
 @app.route('/chat', methods=['POST'])
 def chat():
-    """Handle request to ollama.chat."""
+    """Handle chat request with optional llama_mode parameter."""
     authenticate()
     params = request.get_json()
     model = params.get('model', DEFAULT_MODEL)
     content = params.get('content', '')
+    llama_mode = params.get('llama_mode', 'cli')
+    
     if not content.strip():
         abort(400, description='Missing prompt content')
 
-    response = ollama.chat(
-        model=model,
-        messages=[{'role': 'user', 'content': content}],
-        stream=False
-    )
-
-    return jsonify(response.message.content)
+    response_content = chat_with_model(model, content, llama_mode)
+    return jsonify(response_content)
 
 @app.errorhandler(Exception)
 def internal_error(error):

--- a/ai_server/server.py
+++ b/ai_server/server.py
@@ -134,7 +134,7 @@ def chat_with_llamacpp(model: str, content: str, system_prompt: Optional[str] = 
         raise Exception("Llama.cpp CLI not found")
 
 def chat_with_model(model: str, content: str, llama_mode: str = "cli", system_prompt: Optional[str] = None) -> str:
-    """Route chat request based on llama_mode: server (external), cli, or ollama fallback."""
+    """Route chat request based on llama_mode: server (external), cli, or ollama fallback; and with optional system prompt."""
     if is_llamacpp_available(model):
         if llama_mode == "server":
             if not LLAMA_SERVER_URL:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ license-files = ["LICEN[CS]E*"]
 dependencies = [
     "flask",
     "ollama",
+    "python-dotenv",
     "redis",
+    "requests",
 ]
 
 

--- a/test/test_system_prompt.py
+++ b/test/test_system_prompt.py
@@ -3,7 +3,6 @@ import os
 from unittest.mock import patch, MagicMock
 import sys
 
-os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from ai_server.server import (
@@ -20,6 +19,11 @@ TEST_USER_CONTENT = "Write a function"
 
 class TestSystemPromptCore:
     """Core system prompt functionality tests."""
+    
+    @pytest.fixture(autouse=True)
+    def setup_env(self, monkeypatch):
+        """Set up environment variables for each test."""
+        monkeypatch.setenv('REDIS_URL', 'redis://localhost:6379')
     
     @patch('ai_server.server.subprocess.run')
     @patch('ai_server.server.resolve_model_path')

--- a/test/test_system_prompt.py
+++ b/test/test_system_prompt.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'

--- a/test/test_system_prompt.py
+++ b/test/test_system_prompt.py
@@ -5,13 +5,6 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from ai_server.server import (
-    chat_with_llamacpp,
-    chat_with_llama_server_http,
-    chat_with_ollama,
-    chat_with_model
-)
-
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
 TEST_USER_CONTENT = "Write a function"
@@ -29,6 +22,8 @@ class TestSystemPromptCore:
     @patch('ai_server.server.resolve_model_path')
     def test_llamacpp_cli_with_system_prompt(self, mock_resolve, mock_subprocess):
         """Test system_prompt passed to llama.cpp CLI."""
+        from ai_server.server import chat_with_llamacpp
+        
         mock_resolve.return_value = f'/data1/GGUF/{TEST_MODEL}/{TEST_MODEL}.gguf'
         mock_result = MagicMock()
         mock_result.stdout = b'def function(): pass'
@@ -45,6 +40,8 @@ class TestSystemPromptCore:
     @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
     def test_llama_server_http_with_system_prompt(self, mock_post):
         """Test system_prompt passed to llama-server HTTP."""
+        from ai_server.server import chat_with_llama_server_http
+        
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {'choices': [{'message': {'content': 'result'}}]}
@@ -60,6 +57,8 @@ class TestSystemPromptCore:
     @patch('ai_server.server.ollama.chat')
     def test_ollama_with_system_prompt(self, mock_ollama):
         """Test system_prompt passed to ollama."""
+        from ai_server.server import chat_with_ollama
+        
         mock_response = MagicMock()
         mock_response.message.content = "result"
         mock_ollama.return_value = mock_response
@@ -75,6 +74,8 @@ class TestSystemPromptCore:
     @patch('ai_server.server.is_llamacpp_available')
     def test_chat_with_model_routing(self, mock_available, mock_chat):
         """Test system_prompt passed through chat_with_model routing."""
+        from ai_server.server import chat_with_model
+        
         mock_available.return_value = True
         mock_chat.return_value = "result"
         

--- a/test/test_system_prompt.py
+++ b/test/test_system_prompt.py
@@ -1,9 +1,6 @@
 import pytest
 import os
 from unittest.mock import patch, MagicMock
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
@@ -12,73 +9,72 @@ TEST_USER_CONTENT = "Write a function"
 
 class TestSystemPromptCore:
     """Core system prompt functionality tests."""
-    
+
     @pytest.fixture(autouse=True)
     def setup_env(self, monkeypatch):
         """Set up environment variables for each test."""
         monkeypatch.setenv('REDIS_URL', 'redis://localhost:6379')
-    
+
     @patch('ai_server.server.subprocess.run')
     @patch('ai_server.server.resolve_model_path')
     def test_llamacpp_cli_with_system_prompt(self, mock_resolve, mock_subprocess):
         """Test system_prompt passed to llama.cpp CLI."""
         from ai_server.server import chat_with_llamacpp
-        
+
         mock_resolve.return_value = f'/data1/GGUF/{TEST_MODEL}/{TEST_MODEL}.gguf'
         mock_result = MagicMock()
         mock_result.stdout = b'def function(): pass'
         mock_subprocess.return_value = mock_result
-        
+
         chat_with_llamacpp(TEST_MODEL, TEST_USER_CONTENT, system_prompt=TEST_SYSTEM_PROMPT)
-        
+
         args, kwargs = mock_subprocess.call_args
         cmd = args[0]
         assert '--system-prompt' in cmd
         assert TEST_SYSTEM_PROMPT in cmd
-    
+
     @patch('ai_server.server.requests.post')
     @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
     def test_llama_server_http_with_system_prompt(self, mock_post):
         """Test system_prompt passed to llama-server HTTP."""
         from ai_server.server import chat_with_llama_server_http
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {'choices': [{'message': {'content': 'result'}}]}
         mock_post.return_value = mock_response
-        
+
         chat_with_llama_server_http(TEST_MODEL, TEST_USER_CONTENT, system_prompt=TEST_SYSTEM_PROMPT)
-        
+
         args, kwargs = mock_post.call_args
         messages = kwargs['json']['messages']
         assert messages[0]['role'] == 'system'
         assert messages[0]['content'] == TEST_SYSTEM_PROMPT
-    
+
     @patch('ai_server.server.ollama.chat')
     def test_ollama_with_system_prompt(self, mock_ollama):
         """Test system_prompt passed to ollama."""
         from ai_server.server import chat_with_ollama
-        
+
         mock_response = MagicMock()
         mock_response.message.content = "result"
         mock_ollama.return_value = mock_response
-        
+
         chat_with_ollama(TEST_MODEL, TEST_USER_CONTENT, system_prompt=TEST_SYSTEM_PROMPT)
-        
+
         args, kwargs = mock_ollama.call_args
         messages = kwargs['messages']
         assert messages[0]['role'] == 'system'
         assert messages[0]['content'] == TEST_SYSTEM_PROMPT
-    
+
     @patch('ai_server.server.chat_with_llamacpp')
     @patch('ai_server.server.is_llamacpp_available')
     def test_chat_with_model_routing(self, mock_available, mock_chat):
         """Test system_prompt passed through chat_with_model routing."""
         from ai_server.server import chat_with_model
-        
+
         mock_available.return_value = True
         mock_chat.return_value = "result"
-        
+
         chat_with_model(TEST_MODEL, TEST_USER_CONTENT, 'cli', TEST_SYSTEM_PROMPT)
         mock_chat.assert_called_once_with(TEST_MODEL, TEST_USER_CONTENT, TEST_SYSTEM_PROMPT)
-        

--- a/test/test_system_prompt.py
+++ b/test/test_system_prompt.py
@@ -1,0 +1,79 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+import sys
+
+os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ai_server.server import (
+    chat_with_llamacpp,
+    chat_with_llama_server_http,
+    chat_with_ollama,
+    chat_with_model
+)
+
+TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
+TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
+TEST_USER_CONTENT = "Write a function"
+
+
+class TestSystemPromptCore:
+    """Core system prompt functionality tests."""
+    
+    @patch('ai_server.server.subprocess.run')
+    @patch('ai_server.server.resolve_model_path')
+    def test_llamacpp_cli_with_system_prompt(self, mock_resolve, mock_subprocess):
+        """Test system_prompt passed to llama.cpp CLI."""
+        mock_resolve.return_value = f'/data1/GGUF/{TEST_MODEL}/{TEST_MODEL}.gguf'
+        mock_result = MagicMock()
+        mock_result.stdout = b'def function(): pass'
+        mock_subprocess.return_value = mock_result
+        
+        chat_with_llamacpp(TEST_MODEL, TEST_USER_CONTENT, system_prompt=TEST_SYSTEM_PROMPT)
+        
+        args, kwargs = mock_subprocess.call_args
+        cmd = args[0]
+        assert '--system-prompt' in cmd
+        assert TEST_SYSTEM_PROMPT in cmd
+    
+    @patch('ai_server.server.requests.post')
+    @patch('ai_server.server.LLAMA_SERVER_URL', 'http://localhost:8080')
+    def test_llama_server_http_with_system_prompt(self, mock_post):
+        """Test system_prompt passed to llama-server HTTP."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'choices': [{'message': {'content': 'result'}}]}
+        mock_post.return_value = mock_response
+        
+        chat_with_llama_server_http(TEST_MODEL, TEST_USER_CONTENT, system_prompt=TEST_SYSTEM_PROMPT)
+        
+        args, kwargs = mock_post.call_args
+        messages = kwargs['json']['messages']
+        assert messages[0]['role'] == 'system'
+        assert messages[0]['content'] == TEST_SYSTEM_PROMPT
+    
+    @patch('ai_server.server.ollama.chat')
+    def test_ollama_with_system_prompt(self, mock_ollama):
+        """Test system_prompt passed to ollama."""
+        mock_response = MagicMock()
+        mock_response.message.content = "result"
+        mock_ollama.return_value = mock_response
+        
+        chat_with_ollama(TEST_MODEL, TEST_USER_CONTENT, system_prompt=TEST_SYSTEM_PROMPT)
+        
+        args, kwargs = mock_ollama.call_args
+        messages = kwargs['messages']
+        assert messages[0]['role'] == 'system'
+        assert messages[0]['content'] == TEST_SYSTEM_PROMPT
+    
+    @patch('ai_server.server.chat_with_llamacpp')
+    @patch('ai_server.server.is_llamacpp_available')
+    def test_chat_with_model_routing(self, mock_available, mock_chat):
+        """Test system_prompt passed through chat_with_model routing."""
+        mock_available.return_value = True
+        mock_chat.return_value = "result"
+        
+        chat_with_model(TEST_MODEL, TEST_USER_CONTENT, 'cli', TEST_SYSTEM_PROMPT)
+        mock_chat.assert_called_once_with(TEST_MODEL, TEST_USER_CONTENT, TEST_SYSTEM_PROMPT)
+        

--- a/test/test_system_prompt_api.py
+++ b/test/test_system_prompt_api.py
@@ -1,9 +1,7 @@
 import pytest
 import os
 from unittest.mock import patch
-import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
 TEST_USER_CONTENT = "Write a function"
@@ -11,12 +9,12 @@ TEST_USER_CONTENT = "Write a function"
 
 class TestSystemPromptAPI:
     """Test /chat API endpoint with system_prompt functionality."""
-    
+
     @pytest.fixture(autouse=True)
     def setup_env(self, monkeypatch):
         """Set up environment variables for each test."""
         monkeypatch.setenv('REDIS_URL', 'redis://localhost:6379')
-    
+
     @pytest.fixture
     def client(self):
         """Create test client for Flask app."""
@@ -24,15 +22,15 @@ class TestSystemPromptAPI:
         app.config['TESTING'] = True
         with app.test_client() as client:
             yield client
-    
+
     @patch('ai_server.server.REDIS_CONNECTION')
     @patch('ai_server.server.chat_with_model')
     def test_api_with_system_prompt(self, mock_chat, mock_redis, client):
         """Test /chat endpoint receives and passes system_prompt."""
         mock_redis.get.return_value = b'test_user'
         mock_chat.return_value = "def function(): pass"
-        
-        response = client.post('/chat', 
+
+        response = client.post('/chat',
             headers={'X-API-KEY': 'test-key'},
             json={
                 'model': TEST_MODEL,
@@ -40,23 +38,23 @@ class TestSystemPromptAPI:
                 'system_prompt': TEST_SYSTEM_PROMPT
             }
         )
-        
+
         assert response.status_code == 200
 
         mock_chat.assert_called_once_with(
-            TEST_MODEL, 
-            TEST_USER_CONTENT, 
+            TEST_MODEL,
+            TEST_USER_CONTENT,
             'cli',
             TEST_SYSTEM_PROMPT
         )
-    
+
     @patch('ai_server.server.REDIS_CONNECTION')
     @patch('ai_server.server.chat_with_model')
     def test_api_without_system_prompt(self, mock_chat, mock_redis, client):
         """Test /chat endpoint works without system_prompt."""
         mock_redis.get.return_value = b'test_user'
         mock_chat.return_value = "def function(): pass"
-        
+
         response = client.post('/chat',
             headers={'X-API-KEY': 'test-key'},
             json={
@@ -64,21 +62,21 @@ class TestSystemPromptAPI:
                 'content': TEST_USER_CONTENT
             }
         )
-        
+
         assert response.status_code == 200
-        
+
         mock_chat.assert_called_once_with(
             TEST_MODEL,
             TEST_USER_CONTENT,
             'cli',
             None
         )
-    
+
     @patch('ai_server.server.REDIS_CONNECTION')
     def test_api_authentication_still_required(self, mock_redis, client):
         """Test that authentication is still required with system_prompt."""
         mock_redis.get.return_value = None
-        
+
         response = client.post('/chat',
             headers={'X-API-KEY': 'invalid-key'},
             json={
@@ -87,8 +85,7 @@ class TestSystemPromptAPI:
                 'system_prompt': TEST_SYSTEM_PROMPT
             }
         )
-        
+
         assert response.status_code == 500
         response_data = response.get_json()
         assert "401 Unauthorized" in response_data['error']
-        

--- a/test/test_system_prompt_api.py
+++ b/test/test_system_prompt_api.py
@@ -1,14 +1,12 @@
 import pytest
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import sys
 
-os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from ai_server.server import app
 
-# Test constants
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
 TEST_USER_CONTENT = "Write a function"
@@ -16,6 +14,11 @@ TEST_USER_CONTENT = "Write a function"
 
 class TestSystemPromptAPI:
     """Test /chat API endpoint with system_prompt functionality."""
+    
+    @pytest.fixture(autouse=True)
+    def setup_env(self, monkeypatch):
+        """Set up environment variables for each test."""
+        monkeypatch.setenv('REDIS_URL', 'redis://localhost:6379')
     
     @pytest.fixture
     def client(self):

--- a/test/test_system_prompt_api.py
+++ b/test/test_system_prompt_api.py
@@ -1,0 +1,93 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+import sys
+
+os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ai_server.server import app
+
+# Test constants
+TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
+TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
+TEST_USER_CONTENT = "Write a function"
+
+
+class TestSystemPromptAPI:
+    """Test /chat API endpoint with system_prompt functionality."""
+    
+    @pytest.fixture
+    def client(self):
+        """Create test client for Flask app."""
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            yield client
+    
+    @patch('ai_server.server.REDIS_CONNECTION')
+    @patch('ai_server.server.chat_with_model')
+    def test_api_with_system_prompt(self, mock_chat, mock_redis, client):
+        """Test /chat endpoint receives and passes system_prompt."""
+        mock_redis.get.return_value = b'test_user'
+        mock_chat.return_value = "def function(): pass"
+        
+        response = client.post('/chat', 
+            headers={'X-API-KEY': 'test-key'},
+            json={
+                'model': TEST_MODEL,
+                'content': TEST_USER_CONTENT,
+                'system_prompt': TEST_SYSTEM_PROMPT
+            }
+        )
+        
+        assert response.status_code == 200
+
+        mock_chat.assert_called_once_with(
+            TEST_MODEL, 
+            TEST_USER_CONTENT, 
+            'cli',
+            TEST_SYSTEM_PROMPT
+        )
+    
+    @patch('ai_server.server.REDIS_CONNECTION')
+    @patch('ai_server.server.chat_with_model')
+    def test_api_without_system_prompt(self, mock_chat, mock_redis, client):
+        """Test /chat endpoint works without system_prompt."""
+        mock_redis.get.return_value = b'test_user'
+        mock_chat.return_value = "def function(): pass"
+        
+        response = client.post('/chat',
+            headers={'X-API-KEY': 'test-key'},
+            json={
+                'model': TEST_MODEL,
+                'content': TEST_USER_CONTENT
+            }
+        )
+        
+        assert response.status_code == 200
+        
+        mock_chat.assert_called_once_with(
+            TEST_MODEL,
+            TEST_USER_CONTENT,
+            'cli',
+            None
+        )
+    
+    @patch('ai_server.server.REDIS_CONNECTION')
+    def test_api_authentication_still_required(self, mock_redis, client):
+        """Test that authentication is still required with system_prompt."""
+        mock_redis.get.return_value = None
+        
+        response = client.post('/chat',
+            headers={'X-API-KEY': 'invalid-key'},
+            json={
+                'model': TEST_MODEL,
+                'content': TEST_USER_CONTENT,
+                'system_prompt': TEST_SYSTEM_PROMPT
+            }
+        )
+        
+        assert response.status_code == 500
+        response_data = response.get_json()
+        assert "401 Unauthorized" in response_data['error']
+        

--- a/test/test_system_prompt_api.py
+++ b/test/test_system_prompt_api.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch
 
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'

--- a/test/test_system_prompt_api.py
+++ b/test/test_system_prompt_api.py
@@ -4,9 +4,6 @@ from unittest.mock import patch
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-
-from ai_server.server import app
-
 TEST_MODEL = 'DeepSeek-V3-0324-UD-IQ2_XXS'
 TEST_SYSTEM_PROMPT = "You are a helpful coding assistant."
 TEST_USER_CONTENT = "Write a function"
@@ -23,6 +20,7 @@ class TestSystemPromptAPI:
     @pytest.fixture
     def client(self):
         """Create test client for Flask app."""
+        from ai_server.server import app
         app.config['TESTING'] = True
         with app.test_client() as client:
             yield client


### PR DESCRIPTION
`server.py`:
- Add the optional `system_prompt` parameter and forward `system_prompt` to:
    - ollama.chat()
    - llama-server HTTP API
    - llama.cpp CLI
 